### PR TITLE
Fix path resolution bug

### DIFF
--- a/lib/mix/tasks/committee.install.ex
+++ b/lib/mix/tasks/committee.install.ex
@@ -3,9 +3,8 @@ defmodule Mix.Tasks.Committee.Install do
 
   @shortdoc "Creates a `commit.exs` file and generate executable for git hooks."
 
-  @config_file_name "commit.exs"
-  @config_path Path.expand(@config_file_name)
-  @target_path Path.expand(".git/hooks")
+  @config_path "./commit.exs"
+  @target_path ".git/hooks"
 
   @hooks Committee.__hooks__()
 


### PR DESCRIPTION
Currently Committee uses `Path.expand` to expand to absolute path, but
that'll expand to the fully qualified path even when included as a
dependency, so it'll fail on the client app. This commit fixes that.