### PR TITLE
Bug/fix linting non elixir files

### DIFF
--- a/commit.exs
+++ b/commit.exs
@@ -1,10 +1,11 @@
 defmodule Committee.Commit do
   use Committee
-  import Committee.Helpers, only: [staged_files: 0]
+  import Committee.Helpers, only: [staged_files: 0, staged_files: 1]
 
   @impl true
   def pre_commit do
-    System.cmd("mix", ["format"] ++ staged_files())
+    IO.puts("⚡️ Committee is running your `pre_commit` hook!\n")
+    System.cmd("mix", ["format"] ++ staged_files([".ex", ".exs"]))
     System.cmd("git", ["add"] ++ staged_files())
   end
 end

--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -14,6 +14,16 @@ defmodule Committee.Helpers do
     |> String.split("\n", trim: true)
   end
 
+  @doc """
+  This function returns a list of staged files, but takes in a list of atoms/strings
+  to return by file extensions.
+  """
+  @spec staged_files(String.t() | list(String.t())) :: list(String.t())
+  def staged_files(ext) do
+    staged_files()
+    |> Enum.filter(&String.ends_with?(&1, ext))
+  end
+
   @spec branch_name() :: binary
   def branch_name do
     System.cmd("git", ["rev-parse", "--abbrev-ref", "HEAD"])

--- a/lib/mix/tasks/committee.install.ex
+++ b/lib/mix/tasks/committee.install.ex
@@ -59,7 +59,7 @@ defmodule Mix.Tasks.Committee.Install do
     |> File.write!(~S"""
     defmodule YourApp.Commit do
       use Committee
-      import Committee.Helpers, only: [staged_files: 0]
+      import Committee.Helpers, only: [staged_files: 0, staged_files: 1]
 
       # Here's where you can add your Git hooks!
       #
@@ -71,7 +71,8 @@ defmodule Mix.Tasks.Committee.Install do
       #   # This function auto-runs `mix format` on staged files.
       #   @impl true
       #   def pre_commit do
-      #     System.cmd("mix", ["format"] ++ staged_files())
+      #     IO.puts "⚡️Committee is running your `pre_commit` hook!"
+      #     System.cmd("mix", ["format"] ++ staged_files([".ex", ".exs"]))
       #     System.cmd("git", ["add"] ++ staged_files())
       #   end
       #


### PR DESCRIPTION
This previous version of `staged_files/0` proved a slight bug, because
`mix format` wouldn't be able to run on non-Elixir code.

Clients could mitigate by writing their own filter, but I figured this
could be provided by the `Helpers` module, as it could also potentially
be used for other purposes.

Hence, this commit introduces a new `staged_commit/1` that takes in
either a string or a list of strings that matches on suffix of the
files.

---

This commit updates the installation template to showcase the new
`staged_files/1`, which allows clients to filter staged files by
suffixes (mostly extension, could be really useful to lint only `.ex`
files or `.js` files for example).

---

The previous commits added a new `staged_files/1` which allows for
filter, this commit just updates Committee's own config script to use
that. Dogfooding aye.