### PR TITLE
Make staged_files more robust and warn if commit.exs does not work; Closes #12

### DIFF
--- a/lib/helpers.ex
+++ b/lib/helpers.ex
@@ -9,9 +9,9 @@ defmodule Committee.Helpers do
   """
   @spec staged_files() :: list(String.t())
   def staged_files do
-    System.cmd("git", ["diff", "--name-only", "--cached"])
+    System.cmd("git", ["diff", "-z", "--name-only", "--staged"])
     |> elem(0)
-    |> String.split("\n", trim: true)
+    |> String.split("\0", trim: true)
   end
 
   @doc """

--- a/lib/mix/tasks/committee.runner.ex
+++ b/lib/mix/tasks/committee.runner.ex
@@ -7,6 +7,11 @@ defmodule Mix.Tasks.Committee.Runner do
 
   @impl true
   def run(argv) do
+    if not File.exists?(@config_file_name) do
+      Mix.shell().error("#{@config_file_name} does not exist!")
+      exit({:shutdown, 1})
+    end
+
     {mod, _bytecode} = Code.compile_file(@config_file_name) |> hd
     hook = hd(argv)
 


### PR DESCRIPTION
For a description of changes made, the commit messages are pretty descriptive :smile: 

This PR attempts to address #12 by outputting a clean error message if `commit.exs` is not present