### PR TITLE
Separate installation steps

### DIFF
--- a/lib/mix/tasks/committee.bootstrap.ex
+++ b/lib/mix/tasks/committee.bootstrap.ex
@@ -1,0 +1,20 @@
+defmodule Mix.Tasks.Committee.Bootstrap do
+  use Mix.Task
+
+  @shortdoc "Creates a `.committee.exs` file and generate executable for git hooks."
+
+  @impl true
+  def run([]) do
+    do_run(Mix.Task)
+  end
+
+  @impl true
+  def run([runner]) do
+    do_run(runner)
+  end
+
+  defp do_run(runner) do
+    runner.run("committee.install")
+    runner.run("committee.install_hooks")
+  end
+end

--- a/lib/mix/tasks/committee.install.ex
+++ b/lib/mix/tasks/committee.install.ex
@@ -1,8 +1,7 @@
 defmodule Mix.Tasks.Committee.Install do
   use Mix.Task
-  alias Committee.Hooks
 
-  @shortdoc "Creates a `.committee.exs` file and generate executable for git hooks."
+  @shortdoc "Creates a `.committee.exs` file"
 
   @config_path "./.committee.exs"
 
@@ -15,9 +14,6 @@ defmodule Mix.Tasks.Committee.Install do
       false ->
         Mix.shell().info("Generating `.committee.exs` now..")
         create_config_file()
-
-        Mix.shell().info("Generating git hooks now..")
-        Hooks.create_hooks()
     end
   end
 

--- a/lib/mix/tasks/committee.install_hooks.ex
+++ b/lib/mix/tasks/committee.install_hooks.ex
@@ -1,0 +1,12 @@
+defmodule Mix.Tasks.Committee.InstallHooks do
+  use Mix.Task
+  alias Committee.Hooks
+
+  @shortdoc "Generates executable for git hooks."
+
+  @impl true
+  def run(_) do
+    Mix.shell().info("Generating git hooks now..")
+    Hooks.create_hooks()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -20,3 +20,9 @@ defmodule Committee.TestHelpers do
     |> Path.join(to_string(which))
   end
 end
+
+defmodule Committee.MixTaskStub do
+  def run(task) do
+    send(self(), task)
+  end
+end


### PR DESCRIPTION
I saw the discussion on #17 and while it seems y'all have a plan for going ahead, I figured I'd do something to unblock my own devs. You can use it or not at your discretion.

Basically I separated installation into two distinct steps, which can be run
all at once with an umbrella command (typically by the first developer
adding Committee to a project.)

* `mix committee.bootstrap`
  * Essentially the old `committee.install` task in that it both
    generates the `.committee.exs` file, and installs your git hooks.
* `mix committee.install`
  * A task that solely generates the `.committee.exs` file. Dunno why
    one would use this on their own but I don't ask questions.
* `mix committee.install_hooks`
  * This command solely installs git hooks, and is therefore the
    command that should be placed in your project's README for
    developers to get up and running with your codebase.