### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Get the latest version from [Hex](https://hex.pm/packages/committee)
 ```elixir
 def deps do
   [
-    {:committee, "~> 0.1.2", only: :dev, runtime: false}
+    {:committee, "~> 1.0.0", only: :dev, runtime: false}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Committee.MixProject do
   def project do
     [
       app: :committee,
-      version: "0.2.0",
+      version: "1.0.0",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
This release closes #17 with two PRs, #25 and #26.

Thanks a lot to the contribution from @thiamsantos!

1.0 is now live on Hex :)

(Pushing 1.0 since I think all major bugs should be fixed)